### PR TITLE
Fixed a bug preventing bean from firing namespaced events when there are no handlers

### DIFF
--- a/src/bean.js
+++ b/src/bean.js
@@ -175,7 +175,7 @@
       if (isNamespace) {
         isNamespace = isNamespace.split('.');
         for (k = isNamespace.length; k--;) {
-          handlers[isNamespace[k]] && handlers[isNamespace[k]].apply(element, args);
+          handlers && handlers[isNamespace[k]] && handlers[isNamespace[k]].apply(element, args);
         }
       } else if (!args && element[eventSupport]) {
         fireListener(isNative, type, element);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -369,6 +369,18 @@ sink('namespaces', function (test, ok) {
     Syn.click(el1);
   });
 
+  test('namespace: should be able to fire an event without handlers', 1, function () {
+    var el1 = document.getElementById('foo'), succ;
+    bean.remove(el1);
+    try {
+      bean.fire(el1, 'click.fat');
+      succ = true;
+    } catch (exc) {
+      succ = false;
+    }
+    ok(succ, 'fire namespaced event with no handlers');
+  });
+
   test('namespace: should be able to target namespaced event handlers with fire', 1, function () {
     var el1 = document.getElementById('foo');
     bean.remove(el1);


### PR DESCRIPTION
Basically, bean fails with an exception if you try to `bean.fire('click.fat');` before registering any handler with that namespace.
