### PR TITLE
Fixed a bug with IE8 blowing up when .apply is called with the explicit second parameter set to undefined

### DIFF
--- a/src/bean.js
+++ b/src/bean.js
@@ -175,13 +175,13 @@
       if (isNamespace) {
         isNamespace = isNamespace.split('.');
         for (k = isNamespace.length; k--;) {
-          handlers && handlers[isNamespace[k]] && handlers[isNamespace[k]].apply(element, args);
+          handlers && handlers[isNamespace[k]] && handlers[isNamespace[k]].apply(element, args || []);
         }
       } else if (!args && element[eventSupport]) {
         fireListener(isNative, type, element);
       } else {
         for (k in handlers) {
-          handlers.hasOwnProperty(k) && handlers[k].apply(element, args);
+          handlers.hasOwnProperty(k) && handlers[k].apply(element, args || []);
         }
       }
     }


### PR DESCRIPTION
The code below works in all modern browsers, including IE9, but blows up in IE8.

```
var args = undefined;
function fn() {}
fn.apply({}, args);
> Object expected
```

My patch fixes that in a couple of places so that bean's tests pass.
