### PR TITLE
IE6,7,8 custom event fix for add() triggering events on subsequent adds

### DIFF
--- a/src/bean.js
+++ b/src/bean.js
@@ -36,7 +36,9 @@
   listener = W3C_MODEL ? function (element, type, fn, add) {
     element[add ? addEvent : removeEvent](type, fn, false);
   } : function (element, type, fn, add, custom) {
-    custom && add && (element['_on' + custom] = element['_on' + custom] || 0);
+    if (custom && add && element['_on' + custom] === null) {
+      element['_on' + custom] = 0;
+    }
     element[add ? attachEvent : detachEvent]('on' + type, fn);
   },
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,4 +1,3 @@
-//stub this for ie crap
 if (!window.console) {
   window.console = { log: function () {}}
 }
@@ -109,6 +108,12 @@ sink('add', function (test, ok) {
     var el2 = document.getElementById('bar');
     bean.add(el1, 'click', function () {ok(true, 'bubbles up dom')});
     Syn.click(el2);
+  });
+
+  test('add: shouldn\'t trigger event when adding additional custom event listeners', 0, function () {
+    var el = document.getElementById('input');
+    bean.add(el, 'foo', function () {ok(true, 'additional custom event listeners trigger event 1')});
+    bean.add(el, 'foo', function () {ok(true, 'additional custom event listeners trigger event 2')});
   });
 
 })


### PR DESCRIPTION
IE<=8 has an event triggered each time you add a new custom handler because of the unnecessary assignment to self of the _on<event> property
