### PR TITLE
Removing unnecessary `clean` method

### DIFF
--- a/src/bean.js
+++ b/src/bean.js
@@ -334,18 +334,10 @@
 
   var bean = { add: add, remove: remove, clone: clone, fire: fire };
 
-  var clean = function (el) {
-    var uid = remove(el).__uid;
-    if (uid) {
-      delete collected[uid];
-      delete registry[uid];
-    }
-  };
-
   if (win[attachEvent]) {
     add(win, 'unload', function () {
       for (var k in collected) {
-        collected.hasOwnProperty(k) && clean(collected[k]);
+        collected.hasOwnProperty(k) && remove(collected[k]);
       }
       win.CollectGarbage && CollectGarbage();
     });


### PR DESCRIPTION
It seems like `remove(el)` / `removeListener` now do all the things `clean(el)` does, which wasn't the case when the function was first added in 065a272c1b01d7b482766c081cd0e80de0388829.
