### PR TITLE
Avoid `event.layerX/Y` warnings in WebKit

### DIFF
--- a/src/bean.js
+++ b/src/bean.js
@@ -282,6 +282,7 @@
     result.preventDefault = fixEvent.preventDefault(e);
     result.stopPropagation = fixEvent.stopPropagation(e);
     result.target = target && target.nodeType == 3 ? target.parentNode : target;
+    result.layerX = result.layerY = true;
     if (~type.indexOf('key')) {
       result.keyCode = e.which || e.keyCode;
     } else if ((/click|mouse|menu/i).test(type)) {


### PR DESCRIPTION
See [issue 8 on @ded's ender-tipsy](https://github.com/ded/ender-tipsy/issues/8).

I'm not sure `true` is the best value to use there, but this is the cleanest way I had been able to avoid the warnings.
