### PR TITLE
Make drag and drop events be considered "mouse-related" events.

### DIFF
--- a/src/bean.js
+++ b/src/bean.js
@@ -128,7 +128,7 @@
             if (type.indexOf('key') !== -1) {
               props = keyProps
               result.keyCode = event.which || event.keyCode
-            } else if ((/click|mouse|menu/i).test(type)) {
+            } else if ((/click|mouse|menu|drag|drop/i).test(type)) {
               props = mouseProps
               result.rightClick = event.which === 3 || event.button === 2
               result.pos = { x: 0, y: 0 }


### PR DESCRIPTION
Adding "drag" and "drop" as elements of the regex that detects mouse-related events. (As they are mouse-related events.)

This also indirectly fixes the dagron project (ded/dagron), which didn't work since commit fat/bean@de81689e23f6830beda228a6da743b3843029218 due to that.

Cheers! :D
