### PR TITLE
Prefer keyCode above which in native events

### DIFF
--- a/bean.js
+++ b/bean.js
@@ -150,7 +150,7 @@
           if (isNative) { // we only need basic augmentation on custom events, the rest is too expensive
             if (type.indexOf('key') !== -1) {
               props = keyProps
-              result.keyCode = event.which || event.keyCode
+              result.keyCode = event.keyCode || event.which
             } else if (mouseTypeRegex.test(type)) {
               props = mouseProps
               result.rightClick = event.which === 3 || event.button === 2

--- a/src/bean.js
+++ b/src/bean.js
@@ -141,7 +141,7 @@
           if (isNative) { // we only need basic augmentation on custom events, the rest is too expensive
             if (type.indexOf('key') !== -1) {
               props = keyProps
-              result.keyCode = event.which || event.keyCode
+              result.keyCode = event.keyCode || event.which
             } else if (mouseTypeRegex.test(type)) {
               props = mouseProps
               result.rightClick = event.which === 3 || event.button === 2


### PR DESCRIPTION
At the moment the bean event.keyCode inherents from the original event the integer "which" above "keyCode". I had some trouble in an embedded browser with this. I think one should actually prefer keyCode above which. 
