### PR TITLE
Modify how nested namespaced events are fired/removed

### DIFF
--- a/src/bean.js
+++ b/src/bean.js
@@ -190,20 +190,24 @@
         }
 
         entry.prototype = {
-            // given a list of namespaces, is our entry in any of them?
-            inNamespaces: function (checkNamespaces) {
-              var i, j
+            // given a list of namespaces, does our entry have all of them?
+            hasNamespaces: function(checkNamespaces) {
+              var i, j, isFound
               if (!checkNamespaces)
                 return true
               if (!this.namespaces)
                 return false
               for (i = checkNamespaces.length; i--;) {
+                isFound = false
                 for (j = this.namespaces.length; j--;) {
-                  if (checkNamespaces[i] === this.namespaces[j])
-                    return true
+                  if (checkNamespaces[i] === this.namespaces[j]) {
+                    isFound = true
+                    break
+                  }
                 }
+                if (!isFound) return false
               }
-              return false
+              return true
             }
 
             // match by element, original fn (opt), handler fn (opt)
@@ -340,7 +344,7 @@
           , handlers = registry.get(element, type, handler)
 
         for (i = 0, l = handlers.length; i < l; i++) {
-          if (handlers[i].inNamespaces(namespaces)) {
+          if (handlers[i].hasNamespaces(namespaces)) {
             if ((entry = handlers[i]).eventSupport)
               listener(entry.target, entry.eventType, entry.handler, false, entry.type)
             // TODO: this is problematic, we have a registry.get() and registry.del() that
@@ -483,7 +487,7 @@
             handlers = registry.get(element, type)
             args = [false].concat(args)
             for (j = 0, l = handlers.length; j < l; j++) {
-              if (handlers[j].inNamespaces(names))
+              if (handlers[j].hasNamespaces(names))
                 handlers[j].handler.apply(element, args)
             }
           }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -695,18 +695,31 @@ sink('namespaces', function (test, ok) {
   test('namespace: should be able to target namespaced event handlers with fire', 1, function () {
     var el1 = document.getElementById('foo');
     bean.remove(el1);
-    bean.add(el1, 'click.fat', function () {ok(true, 'targets namespaced event handlers with fire (namespaced)')});
     bean.add(el1, 'click', function () {ok(true, 'targets namespaced event handlers with fire (plain)')});
+    bean.add(el1, 'click.fat', function () {ok(true, 'targets namespaced event handlers with fire (namespaced)')});
     bean.fire(el1, 'click.fat');
   });
 
-  test('namespace: should be able to target multiple namespaced event handlers with fire', 2, function () {
+  test('namespace: should be able to target nested namespaced event handlers with fire', 1, function () {
     var el1 = document.getElementById('foo');
     bean.remove(el1);
-    bean.add(el1, 'click.fat', function () {ok(true, 'target multiple namespaced event handlers with fire')});
-    bean.add(el1, 'click.ded', function () {ok(true, 'targets multiple namespaced event handlers with fire')});
-    bean.add(el1, 'click', function () {ok(true, 'targets multiple namespaced event handlers with fire')});
-    bean.fire(el1, 'click.fat.ded');
+    bean.add(el1, 'click', function () {ok(true, 'click should not get fired')});
+    bean.add(el1, 'click.ded', function () {ok(true, 'click.ded should not get fired')});
+    bean.add(el1, 'click.fat', function () {ok(true, 'click.fat should not get fired')});
+    bean.add(el1, 'click.ded.fat', function () {ok(true, 'click.ded.fat should not get fired')});
+    bean.add(el1, 'click.ded.fooz', function () {ok(true, 'click.ded.fooz should not get fired')});
+    bean.add(el1, 'click.fat.fooz', function () {ok(true, 'click.fat.fooz should not get fired')});
+    bean.add(el1, 'click.ded.fat.fooz', function () {ok(true, 'click.ded.fat.fooz should get fired')});
+    bean.fire(el1, 'click.ded.fat.fooz');
+  });
+
+  test('namespace: should be able to target multiple nested namespaced event handlers with fire', 2, function () {
+    var el1 = document.getElementById('foo');
+    bean.remove(el1);
+    bean.add(el1, 'click.fat.fooz', function () {ok(true, 'click.fat.fooz should get fired')});
+    bean.add(el1, 'click.ded.fooz', function () {ok(true, 'click.ded.fooz should get fired')});
+    bean.add(el1, 'click', function () {ok(true, 'click should not get fired')});
+    bean.fire(el1, 'click.fooz');
   });
 
   test('namespace: should be able to remove handlers based on name', 1, function () {
@@ -718,13 +731,27 @@ sink('namespaces', function (test, ok) {
     Syn.click(el1);
   });
 
-  test('namespace: should be able to remove multiple handlers based on name', 1, function () {
+  test('namespace: should be able to remove nested handlers based on name', 6, function () {
     var el1 = document.getElementById('foo');
     bean.remove(el1);
-    bean.add(el1, 'click.fat', function () {ok(true, 'removes multiple handlers based on name')});
-    bean.add(el1, 'click.ded', function () {ok(true, 'removes multiple handlers based on name')});
-    bean.add(el1, 'click', function () {ok(true, 'removes multiple handlers based on name')});
-    bean.remove(el1, 'click.ded.fat');
+    bean.add(el1, 'click', function () {ok(true, 'click should get fired')});
+    bean.add(el1, 'click.ded', function () {ok(true, 'click.ded should get fired')});
+    bean.add(el1, 'click.fat', function () {ok(true, 'click.fat should get fired')});
+    bean.add(el1, 'click.ded.fat', function () {ok(true, 'click.ded.fat should get fired')});
+    bean.add(el1, 'click.ded.fooz', function () {ok(true, 'click.ded.fooz should get fired')});
+    bean.add(el1, 'click.fat.fooz', function () {ok(true, 'click.fat.fooz should get fired')});
+    bean.add(el1, 'click.ded.fat.fooz', function () {ok(true, 'click.ded.fat.fooz should not get fired')});
+    bean.remove(el1, 'click.ded.fat.fooz');
+    Syn.click(el1);
+  });
+
+  test('namespace: should be able to remove multiple nested handlers based on name', 1, function () {
+    var el1 = document.getElementById('foo');
+    bean.remove(el1);
+    bean.add(el1, 'click.fat.fooz', function () {ok(true, 'click.fat.fooz should not get fired')});
+    bean.add(el1, 'click.ded.fooz', function () {ok(true, 'click.ded.fooz should not get fired')});
+    bean.add(el1, 'click', function () {ok(true, 'click should get fired')});
+    bean.remove(el1, 'click.fooz');
     Syn.click(el1);
   });
 


### PR DESCRIPTION
Currently there is no way to do an exact match when firing/removing events with multiple namespaces -- if I say `fire("click.foo.bar.baz")`, Bean thinks I mean to fire all click events that have any of the "foo", "bar" or "baz" namespaces, when what I want to do is fire events which have (at least) all three namespaces. So this change changes (ha) the behavior so it means exactly that. (Same thing for `remove()`.)

I realize this is a backward compatible change, but if it's any consolation we wouldn't be removing the ability to match "any", because we already have a way to do that: `fire("click.foo click.bar click.baz")`. Also, actually, this is consistent with jQuery. The [jQuery tests](https://github.com/jquery/jquery/blob/master/test/unit/event.js#L485) are a bit unclear, but if you take the changes I've made to the Bean tests, and try reproducing them in the Chrome dev console on a page that has jQuery on it, then you should see that jQuery is doing an "all" match.

If there is another way to do an exact match when firing/removing events without doing this, then I'm all ears...
