### PR TITLE
Change to check on createEvent instead of attachEvent

### DIFF
--- a/bean.js
+++ b/bean.js
@@ -528,7 +528,7 @@
         return handler
       }
 
-    , fireListener = W3C_MODEL ? function (isNative, type, element) {
+    , fireListener = doc.createEvent ? function (isNative, type, element) {
         // modern browsers, do a proper dispatchEvent()
         var evt = doc.createEvent(isNative ? 'HTMLEvents' : 'UIEvents')
         evt[isNative ? 'initEvent' : 'initUIEvent'](type, true, true, win, 1)


### PR DESCRIPTION
Change to check on createEvent instead of attachEvent in firelistener, since the function actually uses createEvent.

We had a problem in IE8 which surprisingly used the firelistener function for modern browsers. In other words, the W3C_MODEL was true. That was because we have a polyfill for attachEvent. But we do not have a polyfill for createEvent, which is actually the method in use in firelistener.

Is it a bug or is it another reason why you check for attachEvent, but uses the createEvent?

The pull request assumes it is a bug and therefore checks for createEvent instead.

Best regards,
Maiken
