### PR TITLE
quoted object keys prevents Closure compiler name mangling

### DIFF
--- a/bean.js
+++ b/bean.js
@@ -706,16 +706,16 @@
       }
 
     , bean = {
-          on                : on
-        , add               : add
-        , one               : one
-        , off               : off
-        , remove            : off
-        , clone             : clone
-        , fire              : fire
-        , Event             : Event
-        , setSelectorEngine : setSelectorEngine
-        , noConflict        : function () {
+          'on'                : on
+        , 'add'               : add
+        , 'one'               : one
+        , 'off'               : off
+        , 'remove'            : off
+        , 'clone'             : clone
+        , 'fire'              : fire
+        , 'Event'             : Event
+        , 'setSelectorEngine' : setSelectorEngine
+        , 'noConflict'        : function () {
             context[name] = old
             return this
           }

--- a/src/ender.js
+++ b/src/ender.js
@@ -21,33 +21,33 @@
 
     , hover = function (enter, leave, i) { // i for internal
         for (i = this.length; i--;) {
-          b.on.call(this, this[i], 'mouseenter', enter)
-          b.on.call(this, this[i], 'mouseleave', leave)
+          b['on'].call(this, this[i], 'mouseenter', enter)
+          b['on'].call(this, this[i], 'mouseleave', leave)
         }
         return this
       }
 
     , methods = {
-          on             : on
-        , addListener    : on
-        , bind           : on
-        , listen         : on
-        , delegate       : add // jQuery compat, same arg order as add()
+          'on'             : on
+        , 'addListener'    : on
+        , 'bind'           : on
+        , 'listen'         : on
+        , 'delegate'       : add // jQuery compat, same arg order as add()
 
-        , one            : one
+        , 'one'            : one
 
-        , off            : off
-        , unbind         : off
-        , unlisten       : off
-        , removeListener : off
-        , undelegate     : off
+        , 'off'            : off
+        , 'unbind'         : off
+        , 'unlisten'       : off
+        , 'removeListener' : off
+        , 'undelegate'     : off
 
-        , emit           : fire
-        , trigger        : fire
+        , 'emit'           : fire
+        , 'trigger'        : fire
 
-        , cloneEvents    : clone
+        , 'cloneEvents'    : clone
 
-        , hover          : hover
+        , 'hover'          : hover
       }
 
     , shortcuts =
@@ -59,7 +59,7 @@
     methods[shortcuts[i]] = integrate('on', shortcuts[i])
   }
 
-  b.setSelectorEngine($)
+  b['setSelectorEngine']($)
 
   $.ender(methods, true)
 }(ender);


### PR DESCRIPTION
This fixes fat/bean#97, which is caused by object literal key names being mistakenly renamed by the Closure compiler when using advanced optimizations. The simplest solution is to quote the object keys to keep Closure from renaming them.
