### PR TITLE
Change Firefox Detection Method

### DIFF
--- a/bean.js
+++ b/bean.js
@@ -91,7 +91,7 @@
         return {
             mouseenter: { base: 'mouseover', condition: check }
           , mouseleave: { base: 'mouseout', condition: check }
-          , mousewheel: { base: /Firefox/.test(navigator.userAgent) ? 'DOMMouseScroll' : 'mousewheel' }
+          , mousewheel: { base: !(typeof InstallTrigger == 'undefined') ? 'DOMMouseScroll' : 'mousewheel' }
         }
       }())
 


### PR DESCRIPTION
Instead of using `navigator.userAgent` string to test for Mozilla Firefox (Which can be spoofed), it may be more robust to use the proprietary `InstallTrigger` variable present in all gecko-based browsers, including Firefox.

Source: https://developer.mozilla.org/en-US/docs/XPInstall_API_Reference/InstallTrigger_Object
