### PR TITLE
Convert w3cNativeEvents to an array properly

### DIFF
--- a/src/bean.js
+++ b/src/bean.js
@@ -42,7 +42,7 @@
         'input invalid '                                                 + // form elements
         'touchstart touchmove touchend touchcancel '                     + // touch
         'gesturestart gesturechange gestureend '                         + // gesture
-        'textinput'                                                      + // TextEvent
+        'textinput '                                                     + // TextEvent
         'readystatechange pageshow pagehide popstate '                   + // window
         'hashchange offline online '                                     + // window
         'afterprint beforeprint '                                        + // printing


### PR DESCRIPTION
textinput was missing a space after, so if it were split the array would have 'textinputreadystatechange' as an item.
