### PR TITLE
Add new event properties

### DIFF
--- a/src/bean.js
+++ b/src/bean.js
@@ -96,7 +96,7 @@
             // a whitelist of properties (for different event types) tells us what to check for and copy
         var commonProps  = str2arr('altKey attrChange attrName bubbles cancelable ctrlKey currentTarget ' +
               'detail eventPhase getModifierState isTrusted metaKey relatedNode relatedTarget shiftKey '  +
-              'srcElement target timeStamp type view which propertyName')
+              'srcElement target timeStamp type view which propertyName path')
           , mouseProps   = commonProps.concat(str2arr('button buttons clientX clientY dataTransfer '      +
               'fromElement offsetX offsetY pageX pageY screenX screenY toElement movementX movementY region'))
           , mouseWheelProps = mouseProps.concat(str2arr('wheelDelta wheelDeltaX wheelDeltaY wheelDeltaZ ' +

--- a/src/bean.js
+++ b/src/bean.js
@@ -98,11 +98,11 @@
               'detail eventPhase getModifierState isTrusted metaKey relatedNode relatedTarget shiftKey '  +
               'srcElement target timeStamp type view which propertyName')
           , mouseProps   = commonProps.concat(str2arr('button buttons clientX clientY dataTransfer '      +
-              'fromElement offsetX offsetY pageX pageY screenX screenY toElement'))
+              'fromElement offsetX offsetY pageX pageY screenX screenY toElement movementX movementY region'))
           , mouseWheelProps = mouseProps.concat(str2arr('wheelDelta wheelDeltaX wheelDeltaY wheelDeltaZ ' +
               'axis')) // 'axis' is FF specific
           , keyProps     = commonProps.concat(str2arr('char charCode key keyCode keyIdentifier '          +
-              'keyLocation location'))
+              'keyLocation location isComposing code'))
           , textProps    = commonProps.concat(str2arr('data'))
           , touchProps   = commonProps.concat(str2arr('touches targetTouches changedTouches scale rotation'))
           , messageProps = commonProps.concat(str2arr('data origin source'))


### PR DESCRIPTION
Some tests were failing because of uncopied properties, so I verified and added each of them.

 * `isComposing`, defined in [DOM Level 3 Events](https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#widl-InputEvent-isComposing)
 * `code`, defined in [DOM Level 3 Events](https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#widl-KeyboardEvent-code)
 * `movementX` and `movementY`, used for [Pointer Lock](https://dvcs.w3.org/hg/pointerlock/raw-file/default/index.html#widl-MouseEvent-movementX)
 * `region`, used with [hit regions](https://html.spec.whatwg.org/multipage/scripting.html#dom-mouseevent-region) in canvases.
 * `path`, used in [Shadow Dom](http://www.w3.org/TR/shadow-dom/#widl-Event-path)